### PR TITLE
Update edit.blade.php

### DIFF
--- a/resources/views/components/table/actions/edit.blade.php
+++ b/resources/views/components/table/actions/edit.blade.php
@@ -1,4 +1,4 @@
-@aware(['record'])
+@props(['record'])
 
 @php
         $attrs = ['class' => 'mr-1 uppercase hover:underline cursor-pointer', 'hx-target' => '#section'];


### PR DESCRIPTION
I'm not sure if there is a specific reason to use `@aware` here or not, but I noticed that it's usage is having an unintended side-effect in that the code is creating a `record` attribute on the anchor tag and the *whole* record is showing as the value of that attribute. As far as I can tell, this isn't needed and furthermore it could become a potential security issue in production environments.

Thanks for the tutorial, by the way! :pray: 